### PR TITLE
ci: Use a composite action to share docs extraction code

### DIFF
--- a/.github/actions/extract-docs/action.yml
+++ b/.github/actions/extract-docs/action.yml
@@ -1,0 +1,37 @@
+name: Fetch and extract docs
+description: Gets the latest release from a repo, gets the docs tarball from that release, and extracts it.
+inputs:
+  subdir:
+    description: Directory for release docs to be extracted to.
+    required: true
+  repo:
+    description: Repository to get the .tar.gz file from.
+    required: true
+  tarball_prefix:
+    description: Prefix used in the name of the .tar.gz file before the -(release number).tar.gz part.
+    required: true
+  token:
+    description: Github token to use for CLI and actions.
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Get version of latest release
+      id: latest-release
+      run: echo "release=$(gh release view -R ${{ inputs.repo }} --json tagName --jq .tagName)" >> $GITHUB_OUTPUT
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+    - name: Get tarball from latest release
+      uses: dsaltares/fetch-gh-release-asset@1.1.2
+      with:
+        repo: ${{ inputs.repo }}
+        version: 'tags/${{ steps.latest-release.outputs.release }}'
+        file: '${{ inputs.tarball_prefix }}-${{ steps.latest-release.outputs.release }}.tar.gz'
+        token: ${{ inputs.token }}
+    - name: Remove placeholder index file
+      run: rm ${{ inputs.subdir }}/index.html
+      shell: bash
+    - name: Extract docs tarball into correct place
+      run: tar -xzf ${{ inputs.tarball_prefix }}-${{ steps.latest-release.outputs.release }}.tar.gz -C ${{ inputs.subdir }}
+      shell: bash

--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -23,38 +23,22 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up Pages
         uses: actions/configure-pages@v3
-      - name: (Lambeq) Get version of latest release
-        id: latest-lambeq
-        run: echo "release=$(gh release view -R isobelhooper/lambeq --json tagName --jq .tagName)" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: (Lambeq) Get tarball from latest release
-        uses: dsaltares/fetch-gh-release-asset@1.1.2
+      # Use a composite action to extract the docs one product at a time.
+      - name: Extract Lambeq docs
+        uses: ./.github/actions/extract-docs
         with:
+          subdir: '${{ env.DOCS_DIR }}/lambeq'
           repo: 'isobelhooper/lambeq'
-          version: 'tags/${{ steps.latest-lambeq.outputs.release }}'
-          file: 'lambeq-docs-${{ steps.latest-lambeq.outputs.release }}.tar.gz'
+          tarball_prefix: 'lambeq-docs'
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: (Lambeq) Remove placeholder index file
-        run: rm ${{ env.DOCS_DIR }}/lambeq/index.html
-      - name: (Lambeq) Extract docs tarball into correct place
-        run: tar -xzf lambeq-docs-${{ steps.latest-lambeq.outputs.release }}.tar.gz -C ${{ env.DOCS_DIR }}/lambeq
-      - name: (Qermit) Get version of latest release
-        id: latest-qermit
-        run: echo "release=$(gh release view -R isobelhooper/Qermit --json tagName --jq .tagName)" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: (Qermit) Get tarball from latest release
-        uses: dsaltares/fetch-gh-release-asset@1.1.2
+      - name: Extract Qermit docs
+        uses: ./.github/actions/extract-docs
         with:
+          subdir: '${{ env.DOCS_DIR }}/qermit'
           repo: 'isobelhooper/Qermit'
-          version: 'tags/${{ steps.latest-qermit.outputs.release }}'
-          file: 'qermit-docs-${{ steps.latest-qermit.outputs.release }}.tar.gz'
+          tarball_prefix: 'qermit-docs'
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: (Qermit) Remove placeholder index file
-        run: rm ${{ env.DOCS_DIR }}/qermit/index.html
-      - name: (Qermit) Extract docs tarball into correct place
-        run: tar -xzf qermit-docs-${{ steps.latest-qermit.outputs.release }}.tar.gz -C ${{ env.DOCS_DIR }}/qermit
+      # Once they're all extracted, we can upload.
       - name: Upload Github Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
The site so far only has two sources, but that's enough to have code duplication.

Tried this with matrix strategy to start with, but that requires
separate jobs for the matrix part and the "deploy it all to Github Pages"
part, and workspaces are only shared within a job, not within a workflow.

So we'd have to cache the extracted tarballs between jobs - which requires
zipping them up again - and that seemed a bit much.

Instead, I've extracted the shared code into an action in this repo,
and we have an entry for each of the included products where we extract
their docs into the correct subdirectory.