### PR TITLE
Add tket docs

### DIFF
--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -45,6 +45,13 @@ jobs:
           repo: 'CQCL-DEV/inquanto-docs'
           tarball_prefix: 'inquanto-docs'
           token: ${{ secrets.INQUANTO_DOCS_READ_ACCESS_TOKEN }}
+      - name: Extract tket docs
+        uses: ./.github/actions/extract-docs
+        with:
+          subdir: '${{ env.DOCS_DIR }}/tket'
+          repo: 'CQCL-DEV/tket-site'
+          tarball_prefix: 'tket-docs'
+          token: ${{ secrets.TKET_DOCS_READ_ACCESS_TOKEN }}
       - name: Extract Lambeq docs
         uses: ./.github/actions/extract-docs
         with:

--- a/base_site/index.html
+++ b/base_site/index.html
@@ -28,6 +28,9 @@
               <a class="nav-link nav-internal" href="h-series/index.html"> H-Series </a>
             </li>
             <li class="nav-item">
+              <a class="nav-link nav-internal" href="tket/index.html"> TKET </a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link nav-internal" href="nexus/index.html"> Nexus </a>
             </li>
             <li class="nav-item">
@@ -58,6 +61,13 @@
                 <h4 class="card-title">H-Series</h4>
                 <p>Ion-trap hardware, H-Series, powered by Honeywell.</p>
                 <a href="h-series/index.html">See H-Series docs</a>
+              </div>
+            </div>
+            <div class="card">
+              <div class="card-body">
+                <h4 class="card-title">TKET</h4>
+                <p>A high-performance quantum compiler that can optimise circuits for a wide range of quantum computing architectures.</p>
+                <a href="tket/index.html">See TKET docs</a>
               </div>
             </div>
             <div class="card">

--- a/base_site/tket/index.html
+++ b/base_site/tket/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<title>tket documentation placeholder</title>
+<body>
+<header>tket documentation placeholder</header>
+<p>This should be replaced by the actual tket documentation when it is built.</p>
+<footer>(placeholder)</footer>
+</body>


### PR DESCRIPTION
Changes:
* Add placeholder index page and directory for tket docs
* Add entry to deploy_site.yml to fetch and extract the tket docs tarball.
* Update (temporary) landing page to include links to TKET site in nav bar and main flow.