### PR TITLE
Add robots.txt for docs.quantinuum.com

### DIFF
--- a/base_site/robots.txt
+++ b/base_site/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+User-agent: AdsBot-Google
+Disallow: /


### PR DESCRIPTION
Since we now have a root domain that we can use for this repo, a robots.txt file will actually be useful.

Reference for this file:
* https://developers.google.com/search/docs/crawling-indexing/robots/intro for what Google expects in robots.txt (you have to specifically call out their ads bot as User-agent: * does not include it).
* https://www.bing.com/webmasters/help/how-to-create-a-robots-txt-file-cb7c31ec and related pages as a reference to what Bing expects. (It doesn't appear to have an adbot that ignores User-agent: * like Google does.)

When we actually have proper landing pages up, we can change this robots.txt file to something that encourages search indexing; but for now, we'd like to discourage it.