### PR TITLE
Add Lambeq docs to the ones being extracted

### DIFF
--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -52,6 +52,13 @@ jobs:
           repo: 'CQCL-DEV/tket-site'
           tarball_prefix: 'tket-docs'
           token: ${{ secrets.TKET_DOCS_READ_ACCESS_TOKEN }}
+      - name: Extract Lambeq docs
+        uses: ./.github/actions/extract-docs
+        with:
+          subdir: '${{ env.DOCS_DIR }}/lambeq'
+          repo: 'CQCL/lambeq'
+          tarball_prefix: 'lambeq-docs'
+          token: ${{ secrets.GITHUB_TOKEN }}
       # Once they're all extracted, we can upload.
       - name: Upload Github Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/base_site/lambeq/index.html
+++ b/base_site/lambeq/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<title>Lambeq documentation placeholder</title>
+<body>
+<header>Lambeq documentation placeholder</header>
+<p>This should be replaced by the actual Lambeq documentation when it is built.</p>
+<footer>(placeholder)</footer>
+</body>


### PR DESCRIPTION
Lambeq isn't in the index page right now, but we can add the latest release to the overall site deployment.