### PR TITLE
Update robots.txt to allow indexing

### DIFF
--- a/base_site/robots.txt
+++ b/base_site/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 User-agent: AdsBot-Google
-Disallow: /
+Allow: /


### PR DESCRIPTION
Since we want to announce our docs site fairly soon, we should allow it to be indexed by search engines.

This involves changing robots.txt so it doesn't block all user agents, and instead allows them.

For now, we're allowing all user agents, but if we run into trouble with certain ones we can change that again later.